### PR TITLE
Cache webpack bundle vars only on server start

### DIFF
--- a/init/server/index.js
+++ b/init/server/index.js
@@ -69,10 +69,10 @@ var renderPage = function (component) {
   return "<!DOCTYPE html>" + ReactDOMServer.renderToStaticMarkup(component);
 };
 
-// JS Bundle sources.
-var WEBPACK_TEST_BUNDLE = process.env.WEBPACK_TEST_BUNDLE;  // Switch to test webpack-dev-server
-var WEBPACK_DEV = process.env.WEBPACK_DEV === "true";       // Switch to dev webpack-dev-server
-var WEBPACK_HOT = process.env.WEBPACK_HOT === "true";
+// JS Bundle sources are set when server is started
+var WEBPACK_TEST_BUNDLE;
+var WEBPACK_DEV;
+var WEBPACK_HOT;
 
 // Dev bundle URLs
 var devBundleJsUrl = "http://127.0.0.1:2992/js/bundle.js";
@@ -173,6 +173,12 @@ app.get("/<%= componentPath %>", function (req, res) {
 
 // Start helper.
 app.start = function (port, callback) {
+  // load webpack ENVs on server start instead of when the file is loaded
+  // so that functional tests can set ENV's before starting the server
+  WEBPACK_TEST_BUNDLE = process.env.WEBPACK_TEST_BUNDLE;
+  WEBPACK_DEV = process.env.WEBPACK_DEV === "true";
+  WEBPACK_HOT = process.env.WEBPACK_HOT === "true";
+
   port = port || PORT;
   clientApi.setBaseUrl(HOST, port);
   app.listen(port, callback || function () {});


### PR DESCRIPTION
Fixes #8

`builder run install-dev` is already documented. This fixes running `test-func` without `dist` existing.

/cc @ryan-roemer 
