### PR TITLE
Bugfix: Protect against NODE_ENV being undefined

### DIFF
--- a/init/server/index.js
+++ b/init/server/index.js
@@ -179,7 +179,7 @@ app.start = function (port, callback) {
   // Start logger, throttled based on NODE_ENV
   app.use(logger({
     streams: [{
-      level: process.env.NODE_ENV.match(/^test/) ?
+      level: process.env.NODE_ENV && process.env.NODE_ENV.match(/^test/) ?
         "error" :
         "info",
       stream: process.stdout


### PR DESCRIPTION
Missed this bug when running `dev`/`hot` outside of tests when `NODE_ENV` isn't defined.

/cc @ryan-roemer 